### PR TITLE
Windows: fix dependency on stdc++ for Windows

### DIFF
--- a/charsetdetect-ae.cabal
+++ b/charsetdetect-ae.cabal
@@ -68,9 +68,9 @@ Source-Repository head
 
 Library
         Exposed-Modules:        Codec.Text.Detect
-        
+
         Build-Depends:          base >= 4.2.0.2 && < 5, bytestring >= 0.9.1.7
-        
+
         -- Needed to ensure correct build on GHC 7.6 when imported by a
         -- library which uses Template Haskell.
         --
@@ -81,8 +81,14 @@ Library
             c-sources: cbits/dso_handle.c
 
         -- This is a bit dodgy since g++ might link in more stuff, but will probably work in practice:
-        Extra-Libraries:        stdc++
-        
+        if os(windows)
+          if arch(x86_64)
+            extra-libraries:    stdc++-6 gcc_s_seh-1
+          else
+            extra-libraries:    stdc++-6 gcc_s_dw2-1
+        else
+          extra-libraries:      stdc++
+
         Include-Dirs:           libcharsetdetect
                                 libcharsetdetect/mozilla/extensions/universalchardet/src/base
                                 libcharsetdetect/nspr-emu


### PR DESCRIPTION
Unfortunately, due to a GHC bug (https://ghc.haskell.org/trac/ghc/ticket/5289#comment:45), you have to link against `stdc++` in a very specific way on Windows in order to make it work correctly when linked against the runtime linker (i.e., GHCi or Template Haskell-loaded code). For instance, the `yi` library loads `charsetdetect-ae` code from the runtime linker, which currently fails with this error (on GHC 8.0.2):

```
Building yi-core-0.13.5...
Preprocessing library yi-core-0.13.5...
[ 1 of 74] Compiling Yi.UI.Common     ( src\Yi\UI\Common.hs, dist\build\Yi\UI\Common.o )
[ 2 of 74] Compiling Yi.Syntax.Layout ( src\Yi\Syntax\Layout.hs, dist\build\Yi\Syntax\Layout.o )
[ 3 of 74] Compiling Yi.String        ( src\Yi\String.hs, dist\build\Yi\String.o )
[ 4 of 74] Compiling Yi.Paths         ( src\Yi\Paths.hs, dist\build\Yi\Paths.o )
[ 5 of 74] Compiling Yi.Monad         ( src\Yi\Monad.hs, dist\build\Yi\Monad.o )
[ 6 of 74] Compiling Yi.Layout        ( src\Yi\Layout.hs, dist\build\Yi\Layout.o )
[ 7 of 74] Compiling Yi.KillRing      ( src\Yi\KillRing.hs, dist\build\Yi\KillRing.o )
ghc.exe: unable to load package `charsetdetect-ae-1.1.0.1'
ghc.exe: C:\Users\RyanGlScott\AppData\Roaming\cabal\x86_64-windows-ghc-8.0.2\charsetdetect-ae-1.1.0.1-4lkXn2MUvw0Hk9vOcPgvCo\HScharsetdetect-ae-1.1.0.1-4lkXn2MUvw0Hk9vOcPgvCo.o: unknown symbol `_Unwind_Resume'
```

This workaround will allow `charsetdetect-ae` to be used in GHCi on Windows with GHC 8.0.1 or later.

This mimics changes that had to be made to the `double-conversion` library in order for it to work under GHCi on Windows. See https://github.com/bos/double-conversion/pull/13.